### PR TITLE
feat(infra): add environment banner and dynamic version display

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata, Viewport } from "next";
 import Shell from "@/components/Shell";
 import Providers from "@/components/Providers";
 import FcmHandler from "@/components/messaging/FcmHandler";
+import EnvironmentBanner from "@/components/layout/shared/EnvironmentBanner";
 
 export const viewport: Viewport = {
     themeColor: "#0F172A",
@@ -51,6 +52,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <body>
         <Providers>
             <FcmHandler />
+            <EnvironmentBanner />
             <Shell>{children}</Shell>
         </Providers>
         </body>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {useRouter, usePathname} from "next/navigation";
 import {useState, useEffect} from "react";
 import {useAuth} from "@/contexts/AuthContext";
 import { useCurrentOrganizationAccess } from "@/hooks/useAccessControl";
+import { ENV } from "@/lib/env";
 
 const COLORS = {
     primary: "#0B5ED7",
@@ -223,8 +224,8 @@ export default function Sidebar() {
                     <div className="d-flex align-items-center justify-content-between">
                         <span className="small text-muted">Easy Maintenance</span>
                         <span className="small" style={{color: COLORS.primaryDark}}>
-              v0 • MVP
-            </span>
+                            {ENV.APP_VERSION} • {ENV.APP_ENV === "production" ? "produção" : ENV.APP_ENV}
+                        </span>
                     </div>
 
                     {/* dica sutil de IA */}

--- a/src/components/layout/shared/EnvironmentBanner.tsx
+++ b/src/components/layout/shared/EnvironmentBanner.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ENV } from "@/lib/env";
+
+export default function EnvironmentBanner() {
+    if (ENV.APP_ENV === "production") return null;
+
+    const label = ENV.APP_ENV === "staging" ? "AMBIENTE DE TESTES — staging" : `AMBIENTE LOCAL — ${ENV.APP_ENV}`;
+
+    return (
+        <div
+            className="text-center py-1 small fw-semibold"
+            style={{ backgroundColor: "#F59E0B", color: "#78350F" }}
+        >
+            ⚠ {label}
+        </div>
+    );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,4 +2,6 @@ export const ENV = {
     API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || "",
     API_BASE_PATH: process.env.NEXT_PUBLIC_API_BASE_PATH,
     ORG_ID: process.env.NEXT_PUBLIC_ORG_ID || "",
+    APP_ENV: process.env.NEXT_PUBLIC_APP_ENV || "development",
+    APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0",
 };


### PR DESCRIPTION
- Add NEXT_PUBLIC_APP_ENV and NEXT_PUBLIC_APP_VERSION to ENV config
- EnvironmentBanner component shows amber warning bar in non-production envs
- Sidebar footer now renders version and env name dynamically instead of hardcoded "v0 • MVP"
- Inject EnvironmentBanner in RootLayout above Shell

Set NEXT_PUBLIC_APP_ENV=staging|production and NEXT_PUBLIC_APP_VERSION via Railway build vars.